### PR TITLE
17-index-pdf-transcripts-metadata

### DIFF
--- a/app/jobs/index_pdf_transcript_job.rb
+++ b/app/jobs/index_pdf_transcript_job.rb
@@ -1,5 +1,3 @@
-require 'shellwords'
-
 class IndexPdfTranscriptJob < ApplicationJob
   queue_as :default
 
@@ -15,9 +13,20 @@ class IndexPdfTranscriptJob < ApplicationJob
 
     if tmp_file.size > 0
       result = SolrService.extract(path: tmp_file.path)
-      # put response in this field
+      transcript = result['file'].to_s.strip
+
+      # put transcript into these fields
+      item.attributes['time_log_t'] ||= []
+      item.attributes['time_log_t'] << pdf_text
       item.attributes['transcripts_t'] ||= []
-      item.attributes['transcripts_t'] << result[File.basename(tmp_file.path)].to_s.strip
+      item.attributes['transcripts_t'] << transcript
+      item.attributes['transcripts_json_t'] ||= []
+      item.attributes['transcripts_json_t'] << {
+        'transcript_t': transcript,
+        'time_log_t': pdf_text
+      }.to_json
+
+      # index the record in Solr
       item.index_record
     end
   end

--- a/app/models/oral_history_item.rb
+++ b/app/models/oral_history_item.rb
@@ -201,7 +201,7 @@ class OralHistoryItem
 
             if child.elements['mods:location/mods:url[@usage="timed log"]'].present?
               time_log_url = child.elements['mods:location/mods:url[@usage="timed log"]'].text
-              transcript = self.generate_transcript(time_log_url)
+              transcript = self.generate_xml_transcript(time_log_url)
               history.attributes["transcripts_json_t"] << {
                 "transcript_t": transcript,
                 "order_i": order
@@ -272,6 +272,7 @@ class OralHistoryItem
           elsif child.name == 'location'
             child.elements.each do |f|
               history.attributes['links_t'] << [f.text, f.attributes['displayLabel']].to_json
+              order = child.elements['mods:part'].present? ? child.elements['mods:part'].attributes['order'] : 1
               if f.attributes['displayLabel'] &&
                 has_xml_transcripts == false &&
                 history.attributes["transcripts_t"].blank? &&
@@ -279,6 +280,9 @@ class OralHistoryItem
                 f.text.match(/pdf/i)
                 history.should_process_pdf_transcripts = true
                 pdf_text = f.text
+                history.attributes["transcripts_json_t"] << {
+                  "order_i": order
+                }.to_json
               end
             end
           elsif child.name == 'physicalDescription'
@@ -367,7 +371,7 @@ class OralHistoryItem
     OralHistoryItem.new(id: id)
   end
 
-  def self.generate_transcript(url)
+  def self.generate_xml_transcript(url)
     tmpl = Nokogiri::XSLT(File.read('public/convert.xslt'))
     resp = Net::HTTP.get(URI(url))
 
@@ -396,8 +400,17 @@ class OralHistoryItem
     Delayed::Job.where("handler LIKE ? AND last_error IS ?", "%job_class: ProcessPeakJob%#{self.id}%", nil).present?
   end
 
+  def transcript_job_queued?
+    Delayed::Job.where("handler LIKE ? AND last_error IS ?", "%job_class: IndexPdfTranscriptJob%#{self.id}%", nil).present?
+  end
+
   def should_process_peaks?
     !has_peaks? && !peak_job_queued?
+  end
+
+  def should_process_pdf_transcripts
+    @should_process_pdf_transcripts ||= false
+    @should_process_pdf_transcripts && !transcript_job_queued?
   end
 
   def self.create_import_tmp_file


### PR DESCRIPTION
rename generate transcripts to xml specific, update to add order and update the job to include needed metadata for the search and transcripts display to work